### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uploadFile(@UploadedFile() file: MemoryStorageFile) {
 
 - `fieldname`: string - name of the field that holds a file
 
-- `options`: optional object of type [`UploadOptions`](https://github.com/Blazity/nest-file-fastify/blob/master/src/options.ts#L3)
+- `options`: optional object of type [`UploadOptions`](src/multipart/options.ts#L4)
 
 ### Array of files
 
@@ -71,7 +71,7 @@ uploadFile(@UploadedFiles() files: MemoryStorageFile[]) {
 
 - `maxCount`: optional number - maximum number of files to accept
 
-- `options`: optional object of type [`UploadOptions`](https://github.com/Blazity/nest-file-fastify/blob/master/src/options.ts#L3)
+- `options`: optional object of type [`UploadOptions`](src/multipart/options.ts#L4)
 
 ### Multiple files
 
@@ -90,9 +90,9 @@ uploadFile(@UploadedFiles() files: { avatar?: MemoryStorageFile[], background?: 
 
 `FileFieldsInterceptor` arguments:
 
-- `uploadFields`: object of type [`UploadField`](https://github.com/Blazity/nest-file-fastify/blob/master/src/interceptors/file-fields-interceptor.ts#L15)
+- `uploadFields`: object of type [`UploadField`](src/interceptors/file-fields-interceptor.ts#L19)
 
-- `options`: optional object of type [`UploadOptions`](https://github.com/Blazity/nest-file-fastify/blob/master/src/options.ts#L3)
+- `options`: optional object of type [`UploadOptions`](src/multipart/options.ts#L4)
 
 ### Any files
 
@@ -108,4 +108,4 @@ uploadFile(@UploadedFiles() files: MemoryStorageFile[]) {
 
 `AnyFilesInterceptor` arguments:
 
-- `options`: optional object of type [`UploadOptions`](https://github.com/Blazity/nest-file-fastify/blob/master/src/options.ts#L3)
+- `options`: optional object of type [`UploadOptions`](src/multipart/options.ts#L4)

--- a/README.md
+++ b/README.md
@@ -7,20 +7,30 @@
 
 </div>
 
-This library adds decorators for [Nest.js](https://github.com/nestjs/nest) to support [fastify-multipart](https://github.com/fastify/fastify-multipart). The API is very similar to the official Nest.js Express file decorators.
+This library adds decorators for [Nest.js](https://github.com/nestjs/nest) to support [@fastify/multipart](https://github.com/fastify/fastify-multipart). The API is very similar to the official Nest.js Express file decorators.
 
 ## Installation
 
 NPM
 
 ```bash
-$ npm install @blazity/nest-file-fastify fastify-multipart
+$ npm install @blazity/nest-file-fastify @fastify/multipart
 ```
 
 Yarn
 
 ```bash
-$ yarn add @blazity/nest-file-fastify fastify-multipart
+$ yarn add @blazity/nest-file-fastify @fastify/multipart
+```
+
+and register multpart plugin in your Nest.js application
+
+```typescript
+import fastyfyMultipart from '@fastify/multipart';
+
+...
+
+app.register(fastyfyMultipart);
 ```
 
 ## Docs
@@ -28,11 +38,11 @@ $ yarn add @blazity/nest-file-fastify fastify-multipart
 ### Single file
 
 ```ts
-import { FileInterceptor, UploadedFile, StorageFile } from '@blazity/nest-file-fastify';
+import { FileInterceptor, UploadedFile, MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Post('upload')
 @UseInterceptors(FileInterceptor('file'))
-uploadFile(@UploadedFile() file: StorageFile) {
+uploadFile(@UploadedFile() file: MemoryStorageFile) {
   console.log(file);
 }
 ```
@@ -46,11 +56,11 @@ uploadFile(@UploadedFile() file: StorageFile) {
 ### Array of files
 
 ```ts
-import { FilesInterceptor, UploadedFiles, StorageFile } from '@blazity/nest-file-fastify';
+import { FilesInterceptor, UploadedFiles, MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Post('upload')
 @UseInterceptors(FilesInterceptor('files'))
-uploadFile(@UploadedFiles() files: StorageFile[]) {
+uploadFile(@UploadedFiles() files: MemoryStorageFile[]) {
   console.log(files);
 }
 ```
@@ -66,14 +76,14 @@ uploadFile(@UploadedFiles() files: StorageFile[]) {
 ### Multiple files
 
 ```ts
-import { FileFieldsInterceptor, UploadedFiles, StorageFile } from '@blazity/nest-file-fastify';
+import { FileFieldsInterceptor, UploadedFiles, MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Post('upload')
 @UseInterceptors(FileFieldsInterceptor([
   { name: 'avatar', maxCount: 1 },
   { name: 'background', maxCount: 1 },
 ]))
-uploadFile(@UploadedFiles() files: { avatar?: StorageFile[], background?: StorageFile[] }) {
+uploadFile(@UploadedFiles() files: { avatar?: MemoryStorageFile[], background?: MemoryStorageFile[] }) {
   console.log(files);
 }
 ```
@@ -87,11 +97,11 @@ uploadFile(@UploadedFiles() files: { avatar?: StorageFile[], background?: Storag
 ### Any files
 
 ```ts
-import { AnyFilesInterceptor, UploadedFiles, StorageFile } from '@blazity/nest-file-fastify';
+import { AnyFilesInterceptor, UploadedFiles, MemoryStorageFile } from '@blazity/nest-file-fastify';
 
 @Post('upload')
 @UseInterceptors(AnyFilesInterceptor()
-uploadFile(@UploadedFiles() files: StorageFile[]) {
+uploadFile(@UploadedFiles() files: MemoryStorageFile[]) {
   console.log(files);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uploadFile(@UploadedFiles() files: { avatar?: MemoryStorageFile[], background?: 
 
 `FileFieldsInterceptor` arguments:
 
-- `uploadFields`: object of type [`UploadField`](src/interceptors/file-fields-interceptor.ts#L19)
+- `uploadFields`: object of type [`UploadField`](src/multipart/handlers/file-fields.ts#L10)
 
 - `options`: optional object of type [`UploadOptions`](src/multipart/options.ts#L4)
 


### PR DESCRIPTION
Fastify updated their libraries to the new version and changed the naming, now the package is called `@fastify/multipart`.

I also changed imports of the `StorageFile` type to `MemoryStorageFile` everywhere, since by default the data is given in the `MemoryStorageFile` format.